### PR TITLE
fix: enhance prompt with framework context and concise output

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -60,7 +60,7 @@ export default function Home() {
       const response = await fetch(`${BACKEND_URL}/enhance-prompt`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message: idea }),
+        body: JSON.stringify({ message: idea, framework }),
       });
       const reader = response.body?.getReader();
       if (!reader) throw new Error('No reader available');


### PR DESCRIPTION
## Summary
- Reuses `getSystemPrompt()` so the enhance endpoint has the same Buildman role context as `/chat`
- Passes the user's selected framework so the LLM knows the tech stack (but is told not to mention it — focus on functionality only)
- Sends last 4 conversation messages as context from Workspace for relevant follow-up enhancements
- Reduces `max_tokens` to 300 to keep enhancements concise

## Test plan
- [ ] On Home page, type "todo app" with React selected → enhanced prompt should describe features/UX without mentioning React/Tailwind
- [ ] On Workspace, enhance a follow-up prompt → should be relevant to the current project context
- [ ] No XML/artifacts/markdown in enhanced output

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)