### PR TITLE
feat: checkpoint preview & revert navigation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@monaco-editor/react": "^4.6.0",
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -1071,6 +1072,52 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.6.0",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/frontend/src/components/ChatTimeline.tsx
+++ b/frontend/src/components/ChatTimeline.tsx
@@ -7,7 +7,8 @@ import { CheckpointCard } from '@/components/CheckpointCard';
 
 interface ChatTimelineProps {
   initialPrompt?: string;
-  onRestore: (id: string) => void;
+  onPreview: (id: string) => void;
+  onRevert: (id: string) => void;
   isWaitingForResponse?: boolean;
 }
 
@@ -44,7 +45,7 @@ function ThinkingBubble() {
   );
 }
 
-export function ChatTimeline({ initialPrompt, onRestore, isWaitingForResponse = false }: ChatTimelineProps) {
+export function ChatTimeline({ initialPrompt, onPreview, onRevert, isWaitingForResponse = false }: ChatTimelineProps) {
   const items = useAppSelector(selectChatItems);
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -79,7 +80,7 @@ export function ChatTimeline({ initialPrompt, onRestore, isWaitingForResponse = 
           return (
             <div key={`${item.checkpointId}-${index}`} className="flex justify-start">
               <div className="w-full max-w-[95%]">
-                <CheckpointCard checkpointId={item.checkpointId} onRestore={onRestore} />
+                <CheckpointCard checkpointId={item.checkpointId} onPreview={onPreview} onRevert={onRevert} />
               </div>
             </div>
           );

--- a/frontend/src/components/CheckpointCard.tsx
+++ b/frontend/src/components/CheckpointCard.tsx
@@ -1,4 +1,5 @@
-import { MoreVertical, RotateCcw } from 'lucide-react';
+import { useState } from 'react';
+import { MoreVertical, Eye, RotateCcw, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -6,6 +7,16 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { Card } from '@/components/ui/card';
 import { useAppSelector } from '@/store/hooks';
 import { selectCheckpoints } from '@/store/selectors';
@@ -19,42 +30,80 @@ function truncate(label: string): string {
 
 interface CheckpointCardProps {
   checkpointId: string;
-  onRestore: (id: string) => void;
+  onPreview: (id: string) => void;
+  onRevert: (id: string) => void;
 }
 
-export function CheckpointCard({ checkpointId, onRestore }: CheckpointCardProps) {
+export function CheckpointCard({ checkpointId, onPreview, onRevert }: CheckpointCardProps) {
   const checkpoints = useAppSelector(selectCheckpoints);
   const cp = checkpoints.find((c) => c.id === checkpointId);
+  const [showRevertConfirm, setShowRevertConfirm] = useState(false);
 
   if (!cp) return null;
 
   return (
-    <Card className="group rounded-lg border border-border bg-card hover:bg-accent/50 transition-colors">
-      <div className="flex items-center gap-2 p-2 min-w-0">
-        <button
-          type="button"
-          className="flex-1 min-w-0 text-left cursor-pointer"
-          onClick={() => onRestore(cp.id)}
-        >
-          <span className="text-sm font-medium text-foreground block truncate" title={cp.label}>
-            {truncate(cp.label)}
-          </span>
-          <span className="text-xs text-muted-foreground">Version {cp.version}</span>
-        </button>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" aria-label="Options">
-              <MoreVertical className="h-4 w-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={() => onRestore(cp.id)}>
-              <RotateCcw className="h-3.5 w-3.5 mr-2" />
-              Restore
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-    </Card>
+    <>
+      <Card className="group rounded-lg border border-border bg-card hover:bg-accent/50 transition-colors">
+        <div className="flex items-center gap-2 p-2 min-w-0">
+          <button
+            type="button"
+            className="flex-1 min-w-0 text-left cursor-pointer"
+            onClick={() => onPreview(cp.id)}
+          >
+            <span className="text-sm font-medium text-foreground block truncate" title={cp.label}>
+              {truncate(cp.label)}
+            </span>
+            <span className="text-xs text-muted-foreground">Version {cp.version}</span>
+          </button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" aria-label="Options">
+                <MoreVertical className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => onPreview(cp.id)}>
+                <Eye className="h-3.5 w-3.5 mr-2" />
+                Preview
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setShowRevertConfirm(true)}>
+                <RotateCcw className="h-3.5 w-3.5 mr-2" />
+                Revert
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </Card>
+
+      <AlertDialog open={showRevertConfirm} onOpenChange={setShowRevertConfirm}>
+        <AlertDialogContent className="max-w-md">
+          <button
+            type="button"
+            onClick={() => setShowRevertConfirm(false)}
+            className="absolute right-4 top-4 rounded-sm p-1 text-white/50 hover:text-white transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+          <AlertDialogHeader className="text-left">
+            <AlertDialogTitle>Revert to this checkpoint?</AlertDialogTitle>
+            <AlertDialogDescription className="text-white/70">
+              All chat messages and versions after this checkpoint will be permanently erased.
+              This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel className="border-white/20 bg-transparent text-white hover:bg-white/10 hover:text-white">
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => onRevert(cp.id)}
+              className="bg-red-500/20 text-red-400 border border-red-500/30 hover:bg-red-500/30 hover:text-red-300"
+            >
+              Revert
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,139 @@
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+const AlertDialog = AlertDialogPrimitive.Root
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-xl border border-white/20 bg-[hsl(142,30%,12%)] p-6 text-white shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogHeader.displayName = "AlertDialogHeader"
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogFooter.displayName = "AlertDialogFooter"
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-white/80", className)}
+    {...props}
+  />
+))
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className
+    )}
+    {...props}
+  />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -52,6 +52,7 @@ export default function Workspace() {
   const {
     createCheckpoint,
     restoreFromCheckpoint,
+    revertFromCheckpoint,
     filesAtLastLlmRef,
     updateFilesAtLastLlmRef,
   } = useCheckpoint();
@@ -156,7 +157,8 @@ export default function Workspace() {
         <div className="flex-1 min-h-0 overflow-y-auto">
           <ChatTimeline
             initialPrompt={prompt}
-            onRestore={restoreFromCheckpoint}
+            onPreview={restoreFromCheckpoint}
+            onRevert={revertFromCheckpoint}
             isWaitingForResponse={isBuildingApp}
           />
         </div>

--- a/frontend/src/store/chatSlice.ts
+++ b/frontend/src/store/chatSlice.ts
@@ -35,9 +35,17 @@ const chatSlice = createSlice({
     clearChat(state) {
       state.items = [];
     },
+    truncateChatAfterCheckpoint(state, action: PayloadAction<string>) {
+      const idx = state.items.findLastIndex(
+        item => item.type === 'checkpoint' && item.checkpointId === action.payload
+      );
+      if (idx !== -1) {
+        state.items = state.items.slice(0, idx + 1);
+      }
+    },
   },
 });
 
-export const { appendChatItems, clearChat } = chatSlice.actions;
+export const { appendChatItems, clearChat, truncateChatAfterCheckpoint } = chatSlice.actions;
 
 export default chatSlice.reducer;

--- a/frontend/src/store/checkpointSlice.ts
+++ b/frontend/src/store/checkpointSlice.ts
@@ -19,9 +19,15 @@ const checkpointSlice = createSlice({
     clearCheckpoints(state) {
       state.checkpoints = [];
     },
+    revertToCheckpoint(state, action: PayloadAction<string>) {
+      const idx = state.checkpoints.findIndex(c => c.id === action.payload);
+      if (idx !== -1) {
+        state.checkpoints = state.checkpoints.slice(0, idx + 1);
+      }
+    },
   },
 });
 
-export const { addCheckpoint, clearCheckpoints } = checkpointSlice.actions;
+export const { addCheckpoint, clearCheckpoints, revertToCheckpoint } = checkpointSlice.actions;
 
 export default checkpointSlice.reducer;


### PR DESCRIPTION
## Summary
- Replace single "Restore" action on checkpoints with **Preview** (loads files, keeps all history) and **Revert** (hard reset: truncates checkpoints and chat after selected one)
- Add confirmation dialog before revert to prevent accidental data loss, styled to match the dark green design system
- Add `revertToCheckpoint` reducer in checkpointSlice and `truncateChatAfterCheckpoint` reducer in chatSlice

## Test plan
- [x] Click a checkpoint label → files/preview update, all checkpoints and chat remain (Preview)
- [x] Open dropdown → click Preview → same behavior as label click
- [x] Open dropdown → click Revert → confirmation dialog appears with warning
- [x] Click Cancel or X on dialog → nothing happens
- [x] Click Revert on dialog → checkpoints and chat after selected one are removed, workspace continues from that checkpoint
- [x] `cd frontend && npx tsc --noEmit` passes with no errors

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)