### PR TITLE
fix: show user message in chat immediately on submit

### DIFF
--- a/frontend/src/store/chatSlice.ts
+++ b/frontend/src/store/chatSlice.ts
@@ -32,6 +32,9 @@ const chatSlice = createSlice({
       }
       state.items.push({ type: 'checkpoint', checkpointId: action.payload.checkpointId });
     },
+    appendUserMessage(state, action: PayloadAction<string>) {
+      state.items.push({ type: 'user', content: action.payload });
+    },
     clearChat(state) {
       state.items = [];
     },
@@ -46,6 +49,6 @@ const chatSlice = createSlice({
   },
 });
 
-export const { appendChatItems, clearChat, truncateChatAfterCheckpoint } = chatSlice.actions;
+export const { appendChatItems, appendUserMessage, clearChat, truncateChatAfterCheckpoint } = chatSlice.actions;
 
 export default chatSlice.reducer;

--- a/frontend/src/store/workspaceSlice.ts
+++ b/frontend/src/store/workspaceSlice.ts
@@ -83,17 +83,17 @@ interface FollowUpResult {
 
 export const submitFollowUp = createAsyncThunk<
   FollowUpResult,
-  { filesAtLastLlmRef: Array<{ path: string; content: string }> | null },
+  { filesAtLastLlmRef: Array<{ path: string; content: string }> | null; userPrompt: string },
   { state: { workspace: WorkspaceState } }
 >(
   'workspace/followUp',
-  async ({ filesAtLastLlmRef }, { getState }) => {
+  async ({ filesAtLastLlmRef, userPrompt }, { getState }) => {
     const { workspace } = getState();
     const currentFlat = flattenFiles(workspace.files);
-    let content = workspace.userPrompt;
+    let content = userPrompt;
     if (filesAtLastLlmRef != null) {
       const block = buildModificationsBlock(filesAtLastLlmRef, currentFlat);
-      if (block) content = `${block}\n\n${workspace.userPrompt}`;
+      if (block) content = `${block}\n\n${userPrompt}`;
     }
     const newMessage = { role: 'user' as const, content };
     const allMessages = [...workspace.llmMessages, newMessage];
@@ -199,7 +199,6 @@ const workspaceSlice = createSlice({
         state.files = files;
         state.llmMessages = action.payload.allMessages;
         state.phase = 'ready';
-        state.userPrompt = '';
         delete state.activeOperations['workspace:followUp'];
       })
       .addCase(submitFollowUp.rejected, (state, action) => {


### PR DESCRIPTION
## Summary
- Show the user's prompt in the chat timeline immediately when submitted, instead of keeping it in the disabled input field
- Clear the input field right away so the UX feels responsive
- Fix empty payload bug: pass `userPrompt` directly to the `submitFollowUp` thunk instead of reading from Redux state (which was already cleared)

## Test plan
- [x] Submit a follow-up prompt → message appears in chat instantly, input clears, "Working on it..." spinner shows below
- [x] Verify the LLM receives the correct prompt (not empty)
- [x] `cd frontend && npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)