### PR TITLE
feat: add Framer Motion animations to Workspace UI

### DIFF
--- a/frontend/src/components/ChatTimeline.tsx
+++ b/frontend/src/components/ChatTimeline.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef } from 'react';
 import { Loader2 } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
 import { useAppSelector } from '@/store/hooks';
 import { selectChatItems } from '@/store/selectors';
 import type { ChatItem } from '@/store/chatSlice';
 import { CheckpointCard } from '@/components/CheckpointCard';
+import { fadeSlideUp, fadeIn, staggerContainer } from '@/utility/motion';
 
 interface ChatTimelineProps {
   initialPrompt?: string;
@@ -36,12 +38,18 @@ function MessageBubble({ item }: { item: ChatItem }) {
 
 function ThinkingBubble() {
   return (
-    <div className="flex justify-start">
+    <motion.div
+      variants={fadeIn}
+      initial="initial"
+      animate="animate"
+      exit="exit"
+      className="flex justify-start"
+    >
       <div className="max-w-[85%] rounded-xl rounded-bl-md border border-border bg-muted/50 px-3 py-2.5 text-sm text-foreground flex items-center gap-2">
         <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
         <span className="text-muted-foreground">Working on it…</span>
       </div>
-    </div>
+    </motion.div>
   );
 }
 
@@ -57,12 +65,16 @@ export function ChatTimeline({ initialPrompt, onPreview, onRevert, isWaitingForR
     if (initialPrompt) {
       return (
         <div ref={scrollRef} className="flex flex-col gap-3 py-2 pr-1">
-          <div className="flex justify-end">
-            <div className="max-w-[85%] rounded-xl rounded-br-md bg-primary/90 text-primary-foreground px-3 py-2 text-sm">
-              {initialPrompt}
+          <motion.div variants={fadeSlideUp} initial="initial" animate="animate">
+            <div className="flex justify-end">
+              <div className="max-w-[85%] rounded-xl rounded-br-md bg-primary/90 text-primary-foreground px-3 py-2 text-sm">
+                {initialPrompt}
+              </div>
             </div>
-          </div>
-          {isWaitingForResponse && <ThinkingBubble />}
+          </motion.div>
+          <AnimatePresence>
+            {isWaitingForResponse && <ThinkingBubble />}
+          </AnimatePresence>
         </div>
       );
     }
@@ -74,22 +86,47 @@ export function ChatTimeline({ initialPrompt, onPreview, onRevert, isWaitingForR
   }
 
   return (
-    <div ref={scrollRef} className="flex flex-col gap-3 overflow-y-auto py-2 pr-1">
-      {items.map((item, index) => {
-        if (item.type === 'checkpoint') {
+    <motion.div
+      ref={scrollRef}
+      className="flex flex-col gap-3 overflow-y-auto py-2 pr-1"
+      variants={staggerContainer}
+      initial="initial"
+      animate="animate"
+    >
+      <AnimatePresence initial={false}>
+        {items.map((item, index) => {
+          if (item.type === 'checkpoint') {
+            return (
+              <motion.div
+                key={`${item.checkpointId}-${index}`}
+                variants={fadeSlideUp}
+                initial="initial"
+                animate="animate"
+                exit="exit"
+                className="flex justify-start"
+              >
+                <div className="w-full max-w-[95%]">
+                  <CheckpointCard checkpointId={item.checkpointId} onPreview={onPreview} onRevert={onRevert} />
+                </div>
+              </motion.div>
+            );
+          }
           return (
-            <div key={`${item.checkpointId}-${index}`} className="flex justify-start">
-              <div className="w-full max-w-[95%]">
-                <CheckpointCard checkpointId={item.checkpointId} onPreview={onPreview} onRevert={onRevert} />
-              </div>
-            </div>
+            <motion.div
+              key={`${item.type}-${index}`}
+              variants={fadeSlideUp}
+              initial="initial"
+              animate="animate"
+              exit="exit"
+            >
+              <MessageBubble item={item} />
+            </motion.div>
           );
-        }
-        return (
-          <MessageBubble key={`${item.type}-${index}`} item={item} />
-        );
-      })}
-      {isWaitingForResponse && <ThinkingBubble />}
-    </div>
+        })}
+      </AnimatePresence>
+      <AnimatePresence>
+        {isWaitingForResponse && <ThinkingBubble />}
+      </AnimatePresence>
+    </motion.div>
   );
 }

--- a/frontend/src/components/CheckpointCard.tsx
+++ b/frontend/src/components/CheckpointCard.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
+import { motion } from 'framer-motion';
 import { MoreVertical, Eye, RotateCcw, X } from 'lucide-react';
+import { fadeSlideUp } from '@/utility/motion';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -43,6 +45,7 @@ export function CheckpointCard({ checkpointId, onPreview, onRevert }: Checkpoint
 
   return (
     <>
+      <motion.div variants={fadeSlideUp} initial="initial" animate="animate" whileHover={{ scale: 1.02 }} transition={{ type: 'tween', duration: 0.15 }}>
       <Card className="group rounded-lg border border-border bg-card hover:bg-accent/50 transition-colors">
         <div className="flex items-center gap-2 p-2 min-w-0">
           <button
@@ -74,6 +77,7 @@ export function CheckpointCard({ checkpointId, onPreview, onRevert }: Checkpoint
           </DropdownMenu>
         </div>
       </Card>
+      </motion.div>
 
       <AlertDialog open={showRevertConfirm} onOpenChange={setShowRevertConfirm}>
         <AlertDialogContent className="max-w-md">

--- a/frontend/src/components/FileExplorer/FileExplorer.tsx
+++ b/frontend/src/components/FileExplorer/FileExplorer.tsx
@@ -1,9 +1,11 @@
 import { useState, useCallback } from 'react';
 import { FolderTree } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
 import FileItem from './FileItem';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { selectFiles } from '@/store/selectors';
 import { setSelectedFile } from '@/store/workspaceSlice';
+import { collapseExpand } from '@/utility/motion';
 
 interface FileNode {
   name: string;
@@ -53,9 +55,20 @@ export default function FileExplorer() {
               path: currentPath
             })}
           />
-          {node.type === 'folder' && isOpen && node.children && (
-            <div>{renderFileTree(node.children, currentPath)}</div>
-          )}
+          <AnimatePresence initial={false}>
+            {node.type === 'folder' && isOpen && node.children && (
+              <motion.div
+                key={`${currentPath}-children`}
+                variants={collapseExpand}
+                initial="initial"
+                animate="animate"
+                exit="exit"
+                style={{ overflow: 'hidden' }}
+              >
+                {renderFileTree(node.children, currentPath)}
+              </motion.div>
+            )}
+          </AnimatePresence>
         </div>
       );
     });

--- a/frontend/src/components/Workspace/Content.tsx
+++ b/frontend/src/components/Workspace/Content.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { motion } from 'framer-motion';
 import type { WebContainer } from '@webcontainer/api';
 import Tabs from './Tabs';
 import CodeEditor from './CodeEditor';
@@ -35,8 +36,11 @@ export default function Content({
     <div className="h-full flex flex-col">
       <Tabs activeTab={activeTab} onTabChange={setActiveTab} onDownload={onDownload} />
       <div className="flex-1 min-h-0 relative">
-        <div
-          className={`absolute inset-0 flex z-0 ${showCode ? 'visible' : 'invisible pointer-events-none'}`}
+        <motion.div
+          className="absolute inset-0 flex z-0"
+          animate={{ opacity: showCode ? 1 : 0 }}
+          transition={{ duration: 0.2, ease: 'easeOut' }}
+          style={{ pointerEvents: showCode ? 'auto' : 'none' }}
           aria-hidden={!showCode}
         >
           <div className="w-64 border-r border-border flex-shrink-0 flex flex-col min-h-0 bg-card">
@@ -45,14 +49,17 @@ export default function Content({
           <div className="flex-1 min-w-0">
             <CodeEditor readOnly={editorReadOnly} />
           </div>
-        </div>
+        </motion.div>
 
-        <div
-          className={`absolute inset-0 z-10 ${showPreview ? 'visible' : 'invisible pointer-events-none'}`}
+        <motion.div
+          className="absolute inset-0 z-10"
+          animate={{ opacity: showPreview ? 1 : 0 }}
+          transition={{ duration: 0.2, ease: 'easeOut' }}
+          style={{ pointerEvents: showPreview ? 'auto' : 'none' }}
           aria-hidden={!showPreview}
         >
           <Preview webContainer={webContainer} />
-        </div>
+        </motion.div>
       </div>
     </div>
   );

--- a/frontend/src/components/Workspace/Preview.tsx
+++ b/frontend/src/components/Workspace/Preview.tsx
@@ -1,8 +1,10 @@
+import { motion, AnimatePresence } from 'framer-motion';
 import type { WebContainer } from '@webcontainer/api';
 import { usePreviewManager } from '../../hooks/usePreviewManager';
 import { useAppSelector } from '@/store/hooks';
 import { selectPreviewState } from '@/store/selectors';
 import type { PreviewStatus } from '@/store/previewSlice';
+import { fadeIn } from '@/utility/motion';
 
 interface PreviewProps {
   webContainer: WebContainer | null;
@@ -38,23 +40,37 @@ export function Preview({ webContainer }: PreviewProps) {
 
   return (
     <div className="w-full h-full flex items-center justify-center">
-      <div className="text-center">
-        <p className="mb-2">{previewState.error ?? display.title}</p>
-        {display.subtitle && (
-          <p className="text-sm text-gray-400 mb-4">{display.subtitle}</p>
-        )}
-        {showSpinner && (
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500 mx-auto" />
-        )}
-        {showStartButton && (
-          <button
-            onClick={startManually}
-            className="mt-2 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-          >
-            {previewState.status === 'error' ? 'Retry' : 'Start Preview'}
-          </button>
-        )}
-      </div>
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={previewState.status}
+          variants={fadeIn}
+          initial="initial"
+          animate="animate"
+          exit="exit"
+          className="text-center"
+        >
+          <p className="mb-2">{previewState.error ?? display.title}</p>
+          {display.subtitle && (
+            <p className="text-sm text-gray-400 mb-4">{display.subtitle}</p>
+          )}
+          {showSpinner && (
+            <motion.div
+              initial={{ opacity: 0, scale: 0.8 }}
+              animate={{ opacity: 1, scale: 1 }}
+              transition={{ duration: 0.2, ease: 'easeOut' }}
+              className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500 mx-auto"
+            />
+          )}
+          {showStartButton && (
+            <button
+              onClick={startManually}
+              className="mt-2 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+            >
+              {previewState.status === 'error' ? 'Retry' : 'Start Preview'}
+            </button>
+          )}
+        </motion.div>
+      </AnimatePresence>
     </div>
   );
 }

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -170,7 +170,7 @@ export default function Workspace() {
               e.preventDefault();
               handleSubmitFollowUp();
             }}
-            className="flex flex-col rounded-xl border border-border bg-muted/30 overflow-hidden focus-within:ring-1 focus-within:ring-ring"
+            className="flex flex-col rounded-2xl border border-white/20 bg-[hsl(var(--hero-via)_/_0.4)] shadow-lg overflow-hidden focus-within:bg-[hsl(var(--hero-via)_/_0.5)] transition-colors"
           >
             <Textarea
               value={userPrompt}

--- a/frontend/src/utility/motion.ts
+++ b/frontend/src/utility/motion.ts
@@ -1,0 +1,25 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeSlideUp: Variants = {
+  initial: { opacity: 0, y: 8 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.25, ease: 'easeOut' } },
+  exit: { opacity: 0, y: -4, transition: { duration: 0.15, ease: 'easeIn' } },
+};
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1, transition: { duration: 0.2, ease: 'easeOut' } },
+  exit: { opacity: 0, transition: { duration: 0.15, ease: 'easeIn' } },
+};
+
+export const staggerContainer: Variants = {
+  animate: {
+    transition: { staggerChildren: 0.05 },
+  },
+};
+
+export const collapseExpand: Variants = {
+  initial: { height: 0, opacity: 0 },
+  animate: { height: 'auto', opacity: 1, transition: { duration: 0.2, ease: 'easeOut' } },
+  exit: { height: 0, opacity: 0, transition: { duration: 0.15, ease: 'easeIn' } },
+};


### PR DESCRIPTION
## Summary
- Add subtle Framer Motion animations across the Workspace page: chat messages fade+slide-up with stagger, checkpoint cards animate in with hover scale, file explorer folders smoothly expand/collapse, code/preview tabs crossfade, and preview status states transition smoothly
- Create shared animation variants (`fadeSlideUp`, `fadeIn`, `staggerContainer`, `collapseExpand`) in `utility/motion.ts` for consistency
- Match Workspace chat input background to the Home page's warm sage-green hero styling

## Test plan
- [x] Submit a follow-up prompt — user message slides in, thinking spinner fades in, response + checkpoint animate in sequence
- [x] Expand/collapse file tree folders — smooth height transition
- [x] Switch code / preview tabs — crossfade transition
- [x] Preview status transitions (building → installing → running) — smooth fade between states
- [x] Hover checkpoint card — subtle scale response
- [x] Workspace chat input background matches Home page input color
- [x] `npx tsc --noEmit` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)