### PR TITLE
chore: clean up frontend duplication and dead code

### DIFF
--- a/frontend/src/steps.ts
+++ b/frontend/src/steps.ts
@@ -48,8 +48,6 @@ export function parseXml(response: string): Step[] {
   
     const xmlContent = xmlMatch[1];
     const steps: Step[] = [];
-    let stepId = 1; // todo - use uuid for unique id generation
-  
     // Extract artifact title
     const artifactTitle = getArtifactTitle(response);
   

--- a/frontend/src/store/workspaceSlice.ts
+++ b/frontend/src/store/workspaceSlice.ts
@@ -1,5 +1,5 @@
 import { createSlice, createAsyncThunk, type PayloadAction } from '@reduxjs/toolkit';
-import type { FileItem, Framework } from '../types';
+import { DEFAULT_FRAMEWORK, type FileItem, type Framework } from '../types';
 import { parseXml } from '../steps';
 import {
   applyStepsToFiles,
@@ -23,8 +23,6 @@ export interface WorkspaceState {
   globalError: string | null;
   isEnhancingPrompt: boolean;
 }
-
-const DEFAULT_FRAMEWORK: Framework = { webapp: 'react', service: '' };
 
 const initialState: WorkspaceState = {
   phase: 'idle',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -16,11 +16,6 @@ export enum StepType {
     path?: string;
   }
   
-  export interface Project {
-    prompt: string;
-    steps: Step[];
-  }
-  
   export interface FileItem {
     name: string;
     type: 'file' | 'folder';
@@ -29,15 +24,12 @@ export enum StepType {
     path: string;
   }
   
-  export interface FileViewerProps {
-    file: FileItem | null;
-    onClose: () => void;
-  }
-
 export interface Framework {
   webapp: string;
   service: string;
 }
+
+export const DEFAULT_FRAMEWORK: Framework = { webapp: 'react', service: '' };
 
 export interface ChatMessage {
   role: string;

--- a/frontend/src/utility/api.ts
+++ b/frontend/src/utility/api.ts
@@ -19,3 +19,35 @@ export const getTemplate = (prompt: string, framework: Framework) => {
 export  const getChatResponse = (messages: ChatMessage[])  =>{
     return  axios.post(`${BACKEND_URL}/chat`, { messages });
 }
+
+/**
+ * Read an SSE stream from a fetch Response, calling `onText` for each
+ * `{ text }` chunk received.  Resolves when the stream ends or `[DONE]`
+ * is received.
+ */
+export async function readSseStream(
+  response: Response,
+  onText: (text: string) => void,
+): Promise<void> {
+  const reader = response.body?.getReader();
+  if (!reader) throw new Error('No reader available');
+  const decoder = new TextDecoder();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    const chunk = decoder.decode(value);
+    const lines = chunk.split('\n');
+    for (const line of lines) {
+      if (line.startsWith('data: ')) {
+        const data = line.slice(6);
+        if (data === '[DONE]') return;
+        try {
+          const parsed = JSON.parse(data);
+          if (parsed.text) onText(parsed.text);
+        } catch {
+          // ignore parse errors
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- **Extract SSE stream reader** — Duplicated ~20-line SSE decoding block in `Home.tsx` and `Workspace.tsx` consolidated into a shared `readSseStream()` utility in `utility/api.ts`. Also fixes an off-by-one bug (`.slice(5)` → `.slice(6)`) when stripping the `"data: "` prefix.
- **Consolidate `DEFAULT_FRAMEWORK`** — Was defined identically in 3 files (`Home.tsx`, `Workspace.tsx`, `workspaceSlice.ts`); now a single export from `types/index.ts`.
- **Deduplicate checkpoint rebuild** — Extracted shared `applyCheckpoint()` helper in `useCheckpoint.ts` to eliminate repeated flat→tree→dispatch logic in `restoreFromCheckpoint` and `revertFromCheckpoint`.
- **Remove dead code** — Deleted unused `Project` interface, unused `FileViewerProps` interface (both in `types/index.ts`), and unused `stepId` variable in `steps.ts`.

**Net: 7 files changed, 61 additions, 88 deletions.**

## Test plan
- [x] Verify `npm run build` succeeds in `frontend/`
- [x] Verify `npx tsc --noEmit` passes with no errors
- [x] Test prompt enhancement on Home page (SSE streaming still works)
- [ ] Test prompt enhancement in Workspace (SSE streaming still works)
- [x] Test checkpoint preview and revert actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)