### PR TITLE
feat: centralized error handling with AppError type

### DIFF
--- a/frontend/src/components/ChatTimeline.tsx
+++ b/frontend/src/components/ChatTimeline.tsx
@@ -1,17 +1,20 @@
-import { useEffect, useRef } from 'react';
-import { Loader2 } from 'lucide-react';
+import { useState, useEffect, useRef } from 'react';
+import { Loader2, AlertCircle, ChevronDown } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAppSelector } from '@/store/hooks';
 import { selectChatItems } from '@/store/selectors';
 import type { ChatItem } from '@/store/chatSlice';
 import { CheckpointCard } from '@/components/CheckpointCard';
+import { Button } from '@/components/ui/button';
 import { fadeSlideUp, fadeIn, staggerContainer } from '@/utility/motion';
+import { extractErrorSummary } from '@/utility/error-parsing';
 
 interface ChatTimelineProps {
   initialPrompt?: string;
   onPreview: (id: string) => void;
   onRevert: (id: string) => void;
   isWaitingForResponse?: boolean;
+  onRetry?: (action: string, context?: string) => void;
 }
 
 function MessageBubble({ item }: { item: ChatItem }) {
@@ -53,7 +56,65 @@ function ThinkingBubble() {
   );
 }
 
-export function ChatTimeline({ initialPrompt, onPreview, onRevert, isWaitingForResponse = false }: ChatTimelineProps) {
+function ErrorBubble({
+  item,
+  onRetry,
+}: {
+  item: Extract<ChatItem, { type: 'error' }>;
+  onRetry?: (action: string, context?: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const buttonLabel = item.retryAction === 'fix-compilation' ? 'Ask to fix it' : 'Retry';
+
+  // Split context on separator to get individual errors, extract first-line summaries
+  const errorSummaries = item.context
+    ? item.context.split('\n\n---\n\n').map(extractErrorSummary)
+    : [];
+
+  return (
+    <div className="flex justify-start">
+      <div className="max-w-[85%] rounded-xl rounded-bl-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm">
+        <div className="flex items-start gap-2">
+          <AlertCircle className="h-4 w-4 shrink-0 text-destructive mt-0.5" />
+          <div className="flex-1 min-w-0">
+            <p className="text-foreground">{item.message}</p>
+            {errorSummaries.length > 0 && (
+              <div className="mt-1.5">
+                <button
+                  type="button"
+                  onClick={() => setExpanded(!expanded)}
+                  className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <ChevronDown className={`h-3 w-3 transition-transform ${expanded ? 'rotate-180' : ''}`} />
+                  {expanded ? 'Hide details' : 'Show details'}
+                </button>
+                {expanded && (
+                  <ul className="mt-1 space-y-1 rounded bg-background/50 p-2 text-xs text-muted-foreground list-disc list-inside">
+                    {errorSummaries.map((summary, i) => (
+                      <li key={i} className="break-words">{summary}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+            {item.retryAction && onRetry && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-2 h-7 text-xs border-destructive/30 hover:bg-destructive/10"
+                onClick={() => onRetry(item.retryAction!, item.context)}
+              >
+                {buttonLabel}
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ChatTimeline({ initialPrompt, onPreview, onRevert, isWaitingForResponse = false, onRetry }: ChatTimelineProps) {
   const items = useAppSelector(selectChatItems);
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -108,6 +169,19 @@ export function ChatTimeline({ initialPrompt, onPreview, onRevert, isWaitingForR
                 <div className="w-full max-w-[95%]">
                   <CheckpointCard checkpointId={item.checkpointId} onPreview={onPreview} onRevert={onRevert} />
                 </div>
+              </motion.div>
+            );
+          }
+          if (item.type === 'error') {
+            return (
+              <motion.div
+                key={`error-${index}`}
+                variants={fadeSlideUp}
+                initial="initial"
+                animate="animate"
+                exit="exit"
+              >
+                <ErrorBubble item={item} onRetry={onRetry} />
               </motion.div>
             );
           }

--- a/frontend/src/components/Workspace/Preview.tsx
+++ b/frontend/src/components/Workspace/Preview.tsx
@@ -1,13 +1,17 @@
+import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { AlertTriangle, ChevronDown, ChevronUp, X } from 'lucide-react';
 import type { WebContainer } from '@webcontainer/api';
 import { usePreviewManager } from '../../hooks/usePreviewManager';
-import { useAppSelector } from '@/store/hooks';
-import { selectPreviewState } from '@/store/selectors';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import { selectPreviewState, selectPreviewErrors } from '@/store/selectors';
+import { clearErrors } from '@/store/previewSlice';
 import type { PreviewStatus } from '@/store/previewSlice';
 import { fadeIn } from '@/utility/motion';
 
 interface PreviewProps {
   webContainer: WebContainer | null;
+  onRequestFix?: (errorContext: string) => void;
 }
 
 /** Status message map for non-running states. */
@@ -17,18 +21,76 @@ const STATUS_DISPLAY: Record<Exclude<PreviewStatus, 'running'>, { title: string;
   mounting: { title: 'Setting up project...', subtitle: 'Mounting files into the container' },
   installing: { title: 'Installing dependencies...', subtitle: 'Running npm install' },
   starting: { title: 'Starting dev server...', subtitle: 'Waiting for Vite to be ready' },
-  error: { title: 'Something went wrong', subtitle: 'Check the console for details' },
+  error: { title: 'Something went wrong' },
 };
 
-export function Preview({ webContainer }: PreviewProps) {
+export function Preview({ webContainer, onRequestFix }: PreviewProps) {
+  const dispatch = useAppDispatch();
   const { startManually } = usePreviewManager({ webContainer });
   const previewState = useAppSelector(selectPreviewState);
+  const previewErrors = useAppSelector(selectPreviewErrors);
+  const [errorExpanded, setErrorExpanded] = useState(false);
+  const hasErrors = previewErrors.length > 0;
+  const allErrorsText = previewErrors.map(e => e.detail).join('\n\n---\n\n');
 
-  // Preview is running — show iframe
+  // Preview is running — show iframe (with optional error banner overlay)
   if (previewState.status === 'running' && previewState.url) {
     return (
-      <div className="w-full h-full">
+      <div className="w-full h-full relative">
         <iframe width="100%" height="100%" src={previewState.url} />
+        <AnimatePresence>
+          {hasErrors && (
+            <motion.div
+              initial={{ y: -40, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              exit={{ y: -40, opacity: 0 }}
+              transition={{ duration: 0.2, ease: 'easeOut' }}
+              className="absolute top-0 left-0 right-0 bg-destructive/95 backdrop-blur-sm text-destructive-foreground shadow-lg z-20"
+            >
+              <div className="flex items-center gap-2 px-3 py-2">
+                <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+                <span className="text-sm font-medium flex-1 truncate">
+                  {previewErrors.length === 1
+                    ? 'Error Detected'
+                    : `${previewErrors.length} Errors Detected`}
+                </span>
+                <div className="flex items-center gap-1 flex-shrink-0">
+                  {onRequestFix && (
+                    <button
+                      onClick={() => onRequestFix(allErrorsText)}
+                      className="text-xs px-2 py-1 rounded bg-destructive-foreground/20 hover:bg-destructive-foreground/30 transition-colors"
+                    >
+                      Ask to fix it
+                    </button>
+                  )}
+                  <button
+                    onClick={() => setErrorExpanded(!errorExpanded)}
+                    className="p-1 rounded hover:bg-destructive-foreground/20 transition-colors"
+                    title={errorExpanded ? 'Collapse' : 'Expand'}
+                  >
+                    {errorExpanded ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+                  </button>
+                  <button
+                    onClick={() => dispatch(clearErrors())}
+                    className="p-1 rounded hover:bg-destructive-foreground/20 transition-colors"
+                    title="Dismiss"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              </div>
+              {errorExpanded && (
+                <ul className="px-3 pb-2 max-h-48 overflow-y-auto space-y-1 list-disc list-inside">
+                  {previewErrors.map((err) => (
+                    <li key={err.id} className="text-xs opacity-90 break-words">
+                      {err.summary}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </motion.div>
+          )}
+        </AnimatePresence>
       </div>
     );
   }
@@ -61,13 +123,26 @@ export function Preview({ webContainer }: PreviewProps) {
               className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500 mx-auto"
             />
           )}
+          {previewState.error && (
+            <p className="text-sm text-gray-400 mb-4 max-w-md break-words">{previewState.error}</p>
+          )}
           {showStartButton && (
-            <button
-              onClick={startManually}
-              className="mt-2 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-            >
-              {previewState.status === 'error' ? 'Retry' : 'Start Preview'}
-            </button>
+            <div className="flex items-center gap-2 justify-center">
+              <button
+                onClick={startManually}
+                className="mt-2 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+              >
+                {previewState.status === 'error' ? 'Retry' : 'Start Preview'}
+              </button>
+              {previewState.status === 'error' && previewState.error && onRequestFix && (
+                <button
+                  onClick={() => onRequestFix(previewState.error!)}
+                  className="mt-2 px-4 py-2 bg-primary text-primary-foreground rounded hover:bg-primary/90"
+                >
+                  Ask to fix it
+                </button>
+              )}
+            </div>
           )}
         </motion.div>
       </AnimatePresence>

--- a/frontend/src/components/Workspace/Tabs.tsx
+++ b/frontend/src/components/Workspace/Tabs.tsx
@@ -1,6 +1,8 @@
 import { Code2, Eye, FolderDown } from 'lucide-react';
 import { Tabs as TabsPrimitive, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
+import { useAppSelector } from '@/store/hooks';
+import { selectHasPreviewErrors } from '@/store/selectors';
 
 interface TabsProps {
   activeTab: 'code' | 'preview';
@@ -9,6 +11,8 @@ interface TabsProps {
 }
 
 export default function Tabs({ activeTab, onTabChange, onDownload }: TabsProps) {
+  const hasErrors = useAppSelector(selectHasPreviewErrors);
+
   return (
     <div className="flex items-center border-b border-border bg-card">
       <TabsPrimitive value={activeTab} onValueChange={(v) => onTabChange(v as 'code' | 'preview')}>
@@ -22,10 +26,13 @@ export default function Tabs({ activeTab, onTabChange, onDownload }: TabsProps) 
           </TabsTrigger>
           <TabsTrigger
             value="preview"
-            className="rounded-md border-0 data-[state=active]:bg-primary/80 data-[state=active]:text-foreground data-[state=active]:shadow-none gap-2 px-4"
+            className="rounded-md border-0 data-[state=active]:bg-primary/80 data-[state=active]:text-foreground data-[state=active]:shadow-none gap-2 px-4 relative"
           >
             <Eye className="h-4 w-4" />
             Preview
+            {hasErrors && (
+              <span className="absolute top-1 right-1 h-2 w-2 rounded-full bg-destructive" />
+            )}
           </TabsTrigger>
         </TabsList>
       </TabsPrimitive>

--- a/frontend/src/hooks/useWebContainer.ts
+++ b/frontend/src/hooks/useWebContainer.ts
@@ -6,7 +6,7 @@ let bootPromise: Promise<WebContainer> | null = null;
 
 function getWebContainer(): Promise<WebContainer> {
   if (bootPromise) return bootPromise;
-  bootPromise = WebContainer.boot();
+  bootPromise = WebContainer.boot({ forwardPreviewErrors: 'exceptions-only' });
   return bootPromise;
 }
 

--- a/frontend/src/store/chatSlice.ts
+++ b/frontend/src/store/chatSlice.ts
@@ -3,7 +3,8 @@ import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 export type ChatItem =
   | { type: 'user'; content: string }
   | { type: 'assistant'; content: string }
-  | { type: 'checkpoint'; checkpointId: string };
+  | { type: 'checkpoint'; checkpointId: string }
+  | { type: 'error'; message: string; context?: string; retryAction?: string };
 
 export interface ChatState {
   items: ChatItem[];
@@ -38,6 +39,12 @@ const chatSlice = createSlice({
     clearChat(state) {
       state.items = [];
     },
+    appendErrorItem(
+      state,
+      action: PayloadAction<{ message: string; context?: string; retryAction?: string }>
+    ) {
+      state.items.push({ type: 'error', ...action.payload });
+    },
     truncateChatAfterCheckpoint(state, action: PayloadAction<string>) {
       const idx = state.items.findLastIndex(
         item => item.type === 'checkpoint' && item.checkpointId === action.payload
@@ -49,6 +56,6 @@ const chatSlice = createSlice({
   },
 });
 
-export const { appendChatItems, appendUserMessage, clearChat, truncateChatAfterCheckpoint } = chatSlice.actions;
+export const { appendChatItems, appendUserMessage, appendErrorItem, clearChat, truncateChatAfterCheckpoint } = chatSlice.actions;
 
 export default chatSlice.reducer;

--- a/frontend/src/store/previewSlice.ts
+++ b/frontend/src/store/previewSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import type { AppError } from '../types/errors';
 
 export type PreviewStatus = 'idle' | 'building' | 'mounting' | 'installing' | 'starting' | 'running' | 'error';
 
@@ -6,12 +7,14 @@ export interface PreviewState {
   url: string;
   status: PreviewStatus;
   error: string | undefined;
+  errors: AppError[];
 }
 
 const initialState: PreviewState = {
   url: '',
   status: 'idle',
   error: undefined,
+  errors: [],
 };
 
 const previewSlice = createSlice({
@@ -27,10 +30,19 @@ const previewSlice = createSlice({
         state.status = 'error';
       }
     },
+    addError(state, action: PayloadAction<AppError>) {
+      if (!state.errors.some(e => e.id === action.payload.id)) {
+        state.errors.push(action.payload);
+      }
+    },
+    clearErrors(state) {
+      state.errors = [];
+    },
     setPreviewRunning(state, action: PayloadAction<string>) {
       state.url = action.payload;
       state.status = 'running';
       state.error = undefined;
+      state.errors = [];
     },
     resetPreview(state) {
       state.url = '';
@@ -43,6 +55,8 @@ const previewSlice = createSlice({
 export const {
   setPreviewStatus,
   setPreviewError,
+  addError,
+  clearErrors,
   setPreviewRunning,
   resetPreview,
 } = previewSlice.actions;

--- a/frontend/src/store/selectors.ts
+++ b/frontend/src/store/selectors.ts
@@ -67,3 +67,9 @@ export const selectIsSubmitDisabled = createSelector(
   [selectIsFollowUpDisabled, selectUserPrompt],
   (followUpDisabled, prompt) => followUpDisabled || !prompt.trim()
 );
+
+export const selectPreviewErrors = (state: RootState) => state.preview.errors;
+export const selectHasPreviewErrors = createSelector(
+  selectPreviewErrors,
+  (errors) => errors.length > 0
+);

--- a/frontend/src/types/errors.ts
+++ b/frontend/src/types/errors.ts
@@ -1,0 +1,20 @@
+export enum ErrorCategory {
+  Compilation = 'compilation',
+  Runtime = 'runtime',
+  Install = 'install',
+}
+
+export enum ErrorSource {
+  DevServer = 'dev-server',
+  PreviewMessage = 'preview-message',
+  NpmInstall = 'npm-install',
+}
+
+export interface AppError {
+  id: string;
+  summary: string;
+  detail: string;
+  category: ErrorCategory;
+  source: ErrorSource;
+  timestamp: string;
+}

--- a/frontend/src/utility/error-parsing.ts
+++ b/frontend/src/utility/error-parsing.ts
@@ -1,0 +1,101 @@
+import { ErrorCategory, ErrorSource } from '../types/errors';
+import type { AppError } from '../types/errors';
+
+// eslint-disable-next-line no-control-regex
+const ANSI_REGEX = /\x1b\[[0-9;]*[a-zA-Z]/g;
+
+const COMPILATION_ERROR_PATTERNS = [
+  /\[vite\].*error/i,
+  /SyntaxError:/,
+  /TypeError:/,
+  /ReferenceError:/,
+  /Cannot find module/,
+  /Failed to resolve import/,
+  /Unexpected token/,
+  /Module not found/,
+  /does not provide an export named/,
+];
+
+const VITE_SUCCESS_PATTERNS = [
+  /hmr update/i,
+  /page reload/i,
+  /ready in \d+/i,
+  /vite.*dev server running/i,
+  /built in \d+/i,
+];
+
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI_REGEX, '');
+}
+
+export function extractSummary(text: string): string {
+  const lines = text.split('\n').map(l => l.trim()).filter(Boolean);
+  for (const line of lines) {
+    if (/^\d+\s*\|/.test(line) || /^>\s*\d+\s*\|/.test(line) || /^\^/.test(line) || /^\|/.test(line)) continue;
+    if (/^[\s^~]+$/.test(line)) continue;
+    return line.slice(0, 200);
+  }
+  return lines[0]?.slice(0, 200) ?? text.slice(0, 200);
+}
+
+/** Re-export for backward compat */
+export const extractErrorSummary = extractSummary;
+
+export function normalizeForDedup(text: string): string {
+  return text.toLowerCase().replace(/\s+/g, ' ').trim().slice(0, 120);
+}
+
+function makeAppError(
+  rawDetail: string,
+  category: ErrorCategory,
+  source: ErrorSource,
+): AppError {
+  const detail = stripAnsi(rawDetail).trim().slice(0, 500);
+  const summary = extractSummary(detail);
+  const id = normalizeForDedup(summary);
+  return {
+    id,
+    summary,
+    detail,
+    category,
+    source,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export function parseDevServerOutput(raw: string): AppError | null {
+  const cleaned = stripAnsi(raw);
+  for (const pattern of COMPILATION_ERROR_PATTERNS) {
+    if (pattern.test(cleaned)) {
+      return makeAppError(raw, ErrorCategory.Compilation, ErrorSource.DevServer);
+    }
+  }
+  return null;
+}
+
+export function isCompilationSuccess(raw: string): boolean {
+  const cleaned = stripAnsi(raw);
+  return VITE_SUCCESS_PATTERNS.some((pattern) => pattern.test(cleaned));
+}
+
+export function parsePreviewMessage(message: { type: string; message?: string }): AppError | null {
+  if (message.type !== 'PREVIEW_UNCAUGHT_EXCEPTION' && message.type !== 'PREVIEW_UNHANDLED_REJECTION') {
+    return null;
+  }
+  const text = (message.message || '').slice(0, 500);
+  if (!text) return null;
+  return makeAppError(text, ErrorCategory.Runtime, ErrorSource.PreviewMessage);
+}
+
+export function parseInstallResult(exitCode: number, output: string): AppError | null {
+  if (exitCode === 0) return null;
+
+  const npmErrorLines = output
+    .split('\n')
+    .filter((line) => line.startsWith('npm ERR!') || line.startsWith('npm error'))
+    .slice(0, 10)
+    .join('\n');
+
+  const detail = npmErrorLines || `npm install failed with exit code ${exitCode}`;
+  return makeAppError(detail, ErrorCategory.Install, ErrorSource.NpmInstall);
+}

--- a/frontend/src/utility/webcontainer-service.ts
+++ b/frontend/src/utility/webcontainer-service.ts
@@ -45,7 +45,8 @@ export async function syncChangedFiles(
  * Pipes output to console. Resolves when install completes.
  */
 export async function runInstall(
-  webContainer: WebContainer
+  webContainer: WebContainer,
+  onData?: (data: string) => void
 ): Promise<WebContainerProcess> {
   const process = await webContainer.spawn('npm', ['install']);
 
@@ -53,6 +54,7 @@ export async function runInstall(
     new WritableStream({
       write(data) {
         console.log('[Install]', data);
+        onData?.(data);
       },
     })
   );
@@ -65,7 +67,8 @@ export async function runInstall(
  * Pipes output to console. Does NOT wait for exit (dev server runs indefinitely).
  */
 export async function runDevServer(
-  webContainer: WebContainer
+  webContainer: WebContainer,
+  onData?: (data: string) => void
 ): Promise<WebContainerProcess> {
   const process = await webContainer.spawn('npm', ['run', 'dev']);
 
@@ -73,6 +76,7 @@ export async function runDevServer(
     new WritableStream({
       write(data) {
         console.log('[Dev]', data);
+        onData?.(data);
       },
     })
   );


### PR DESCRIPTION
## Summary
- Introduces a structured `AppError` type with `ErrorCategory`/`ErrorSource` enums and normalized dedup IDs
- Centralizes all error parsing into `error-parsing.ts` — ANSI stripping, summary extraction, pattern matching for dev server, preview runtime, and npm install errors
- Replaces ad-hoc string-based error tracking in `previewSlice` with `AppError[]` and id-based deduplication
- Adds error banner overlay on preview iframe (dismiss, expand details, "ask to fix it")
- Adds `ErrorBubble` component in chat timeline with expandable details and retry actions
- Adds red dot error indicator on Preview tab
- Wires `usePreviewManager` to use parse functions with 2s debounced LLM error batching
- Enables `forwardPreviewErrors: 'exceptions-only'` in WebContainer boot config

## Architecture
```
Source                    Parse                      Store                  UI
─────                     ─────                      ─────                  ──
Dev server stdout   →  parseDevServerOutput()   →  dispatch(addError)   →  Preview banner
                       isCompilationSuccess()   →  dispatch(clearErrors)

Preview message     →  parsePreviewMessage()    →  dispatch(addError)   →  Preview banner

npm install         →  parseInstallResult()     →  dispatch(setPreviewError) → Preview status

                       (if isLlmChangeRef)
                       queueLlmError(AppError)  →  2s debounce
                                                →  dispatch(appendErrorItem) → Chat ErrorBubble
```

## Files Changed
| File | Action |
|------|--------|
| `types/errors.ts` | **CREATE** — AppError, ErrorCategory, ErrorSource |
| `utility/error-parsing.ts` | **CREATE** — all parsing functions, ANSI stripping |
| `store/previewSlice.ts` | **MODIFY** — `errors: AppError[]`, `addError`, `clearErrors` |
| `store/selectors.ts` | **MODIFY** — add `selectPreviewErrors`, `selectHasPreviewErrors` |
| `store/chatSlice.ts` | **MODIFY** — add error chat item type, `appendErrorItem` |
| `hooks/usePreviewManager.ts` | **MODIFY** — use parse functions, AppError-based LLM batching |
| `hooks/useWebContainer.ts` | **MODIFY** — enable `forwardPreviewErrors` |
| `utility/webcontainer-service.ts` | **MODIFY** — add `onData` callbacks to install/dev server |
| `components/Workspace/Preview.tsx` | **MODIFY** — error banner overlay with dismiss/expand/fix |
| `components/Workspace/Tabs.tsx` | **MODIFY** — red dot error indicator |
| `components/ChatTimeline.tsx` | **MODIFY** — ErrorBubble component, onRetry prop |

## Test plan
- [ ] LLM generates broken code → 1 error in chat + 1 error in banner (not duplicated)
- [ ] User edits code to break it → red dot + banner, NO chat item
- [ ] User fixes code → HMR success clears banner + red dot
- [ ] ANSI codes stripped from all displayed errors
- [ ] npm install failure shows error in chat and preview status
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)