### PR TITLE
feat: error handling 

### DIFF
--- a/frontend/src/components/ConnectionErrorBanner.tsx
+++ b/frontend/src/components/ConnectionErrorBanner.tsx
@@ -1,0 +1,36 @@
+import { AlertTriangle } from 'lucide-react';
+import { motion } from 'framer-motion';
+import { Button } from './ui/button';
+import { collapseExpand } from '../utility/motion';
+
+interface ConnectionErrorBannerProps {
+  onTryAgain: () => void;
+}
+
+export function ConnectionErrorBanner({ onTryAgain }: ConnectionErrorBannerProps) {
+  return (
+    <motion.div
+      initial="initial"
+      animate="animate"
+      exit="exit"
+      variants={collapseExpand}
+      className="mb-4 rounded-xl border border-red-500/25 bg-red-950/25 overflow-hidden"
+    >
+      <div className="p-4 flex flex-col gap-3">
+        <div className="flex items-center gap-2">
+          <AlertTriangle className="h-5 w-5 text-red-500/90 shrink-0" />
+          <h3 className="font-medium text-red-100 text-sm leading-tight">
+            Something went wrong, please try again.
+          </h3>
+        </div>
+        <Button
+          onClick={onTryAgain}
+          size="sm"
+          className="w-fit bg-primary text-primary-foreground hover:opacity-90"
+        >
+          Try again
+        </Button>
+      </div>
+    </motion.div>
+  );
+}

--- a/frontend/src/components/ErrorBox.tsx
+++ b/frontend/src/components/ErrorBox.tsx
@@ -1,0 +1,81 @@
+import { AlertTriangle, X } from 'lucide-react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useAppSelector } from '../store/hooks';
+import { selectCurrentError } from '../store/selectors';
+import { clearAppError } from '../store/errorSlice';
+import { useAppDispatch } from '../store/hooks';
+import { Button } from './ui/button';
+import { collapseExpand } from '../utility/motion';
+
+interface ErrorBoxProps {
+  onAskToFix: (errorDetail: string) => void;
+}
+
+export function ErrorBox({ onAskToFix }: ErrorBoxProps) {
+  const dispatch = useAppDispatch();
+  const error = useAppSelector(selectCurrentError);
+
+  if (!error) return null;
+
+  const handleDismiss = () => {
+    dispatch(clearAppError());
+  };
+
+  const handleAskToFix = () => {
+    dispatch(clearAppError());
+    onAskToFix(error.detail);
+  };
+
+  return (
+    <AnimatePresence>
+      {error && (
+        <motion.div
+          initial="initial"
+          animate="animate"
+          exit="exit"
+          variants={collapseExpand}
+          className="mb-4 rounded-xl border border-red-500/25 bg-red-950/25 overflow-hidden"
+        >
+          <div className="p-4 flex flex-col gap-3">
+            <div className="flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-red-500/90 shrink-0" />
+              <h3 className="font-medium text-red-100 text-sm leading-tight">
+                Error Detected
+              </h3>
+              <div className="flex-1 min-w-0" />
+              <button
+                onClick={handleDismiss}
+                className="text-red-400/80 hover:text-red-200 transition-colors shrink-0"
+                title="Dismiss"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="flex flex-col gap-3">
+              <p className="text-sm text-red-200/90 leading-tight">
+                {error.summary}
+              </p>
+              {error.filePath && (
+                <p className="text-xs text-red-300/70 font-mono">
+                  {error.filePath}
+                </p>
+              )}
+              <div className="p-2.5 rounded-lg bg-red-950/40 border border-red-500/20">
+                <pre className="text-xs text-red-200/80 whitespace-pre-wrap break-all font-mono max-h-24 overflow-y-auto">
+                  {error.detail}
+                </pre>
+              </div>
+              <Button
+                onClick={handleAskToFix}
+                size="sm"
+                className="w-fit bg-primary text-primary-foreground hover:opacity-90"
+              >
+                Ask to fix it
+              </Button>
+            </div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/components/Workspace/Preview.tsx
+++ b/frontend/src/components/Workspace/Preview.tsx
@@ -2,7 +2,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import type { WebContainer } from '@webcontainer/api';
 import { usePreviewManager } from '../../hooks/usePreviewManager';
 import { useAppSelector } from '@/store/hooks';
-import { selectPreviewState } from '@/store/selectors';
+import { selectPreviewState, selectGlobalError } from '@/store/selectors';
 import type { PreviewStatus } from '@/store/previewSlice';
 import { fadeIn } from '@/utility/motion';
 
@@ -23,6 +23,21 @@ const STATUS_DISPLAY: Record<Exclude<PreviewStatus, 'running'>, { title: string;
 export function Preview({ webContainer }: PreviewProps) {
   const { startManually } = usePreviewManager({ webContainer });
   const previewState = useAppSelector(selectPreviewState);
+  const globalError = useAppSelector(selectGlobalError);
+
+  // Connection/backend error — show message in sync with sidebar (no spinner)
+  if (globalError) {
+    return (
+      <div className="w-full h-full flex items-center justify-center">
+        <div className="text-center max-w-sm">
+          <p className="mb-2">Something went wrong, please try again.</p>
+          <p className="text-sm text-muted-foreground">
+            Use the button in the sidebar to try again.
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   // Preview is running — show iframe
   if (previewState.status === 'running' && previewState.url) {

--- a/frontend/src/components/Workspace/Tabs.tsx
+++ b/frontend/src/components/Workspace/Tabs.tsx
@@ -1,6 +1,8 @@
 import { Code2, Eye, FolderDown } from 'lucide-react';
 import { Tabs as TabsPrimitive, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
+import { useAppSelector } from '@/store/hooks';
+import { selectHasPreviewError } from '@/store/selectors';
 
 interface TabsProps {
   activeTab: 'code' | 'preview';
@@ -9,6 +11,8 @@ interface TabsProps {
 }
 
 export default function Tabs({ activeTab, onTabChange, onDownload }: TabsProps) {
+  const hasError = useAppSelector(selectHasPreviewError);
+
   return (
     <div className="flex items-center border-b border-border bg-card">
       <TabsPrimitive value={activeTab} onValueChange={(v) => onTabChange(v as 'code' | 'preview')}>
@@ -25,7 +29,12 @@ export default function Tabs({ activeTab, onTabChange, onDownload }: TabsProps) 
             className="rounded-md border-0 data-[state=active]:bg-primary/80 data-[state=active]:text-foreground data-[state=active]:shadow-none gap-2 px-4"
           >
             <Eye className="h-4 w-4" />
-            Preview
+            <span className="inline-flex items-center gap-1.5">
+              Preview
+              {hasError && (
+                <span className="h-2 w-2 rounded-full bg-red-500 shrink-0" />
+              )}
+            </span>
           </TabsTrigger>
         </TabsList>
       </TabsPrimitive>

--- a/frontend/src/hooks/useWebContainer.ts
+++ b/frontend/src/hooks/useWebContainer.ts
@@ -6,7 +6,7 @@ let bootPromise: Promise<WebContainer> | null = null;
 
 function getWebContainer(): Promise<WebContainer> {
   if (bootPromise) return bootPromise;
-  bootPromise = WebContainer.boot();
+  bootPromise = WebContainer.boot({ forwardPreviewErrors: 'exceptions-only' });
   return bootPromise;
 }
 

--- a/frontend/src/store/errorSlice.ts
+++ b/frontend/src/store/errorSlice.ts
@@ -1,0 +1,79 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import { editFile, initWorkspace, submitFollowUp } from './workspaceSlice';
+
+export type ErrorSource = 'npm-install' | 'vite-compilation' | 'runtime' | 'dev-server-crash';
+
+export interface AppError {
+  id: string;
+  source: ErrorSource;
+  summary: string;
+  detail: string;
+  filePath?: string;
+  dedupKey: string;
+  isLlmCaused: boolean;
+}
+
+export interface ErrorState {
+  current: AppError | null;
+  lastUserEditTimestamp: number | null;
+  lastLlmCompleteTimestamp: number | null;
+}
+
+const initialState: ErrorState = {
+  current: null,
+  lastUserEditTimestamp: null,
+  lastLlmCompleteTimestamp: null,
+};
+
+function computeIsLlmCaused(
+  lastLlmCompleteTimestamp: number | null,
+  lastUserEditTimestamp: number | null
+): boolean {
+  if (lastLlmCompleteTimestamp === null) return false;
+  if (lastUserEditTimestamp === null) return true;
+  return lastLlmCompleteTimestamp > lastUserEditTimestamp;
+}
+
+const errorSlice = createSlice({
+  name: 'error',
+  initialState,
+  reducers: {
+    setAppError(
+      state,
+      action: PayloadAction<Omit<AppError, 'isLlmCaused'>>
+    ) {
+      const payload = action.payload;
+      if (state.current && state.current.dedupKey === payload.dedupKey) {
+        return;
+      }
+      const isLlmCaused = computeIsLlmCaused(
+        state.lastLlmCompleteTimestamp,
+        state.lastUserEditTimestamp
+      );
+      state.current = {
+        ...payload,
+        isLlmCaused,
+      };
+    },
+    clearAppError(state) {
+      state.current = null;
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(editFile, (state) => {
+      state.lastUserEditTimestamp = Date.now();
+      state.current = null;
+    });
+    builder.addCase(initWorkspace.fulfilled, (state) => {
+      state.lastLlmCompleteTimestamp = Date.now();
+      state.current = null;
+    });
+    builder.addCase(submitFollowUp.fulfilled, (state) => {
+      state.lastLlmCompleteTimestamp = Date.now();
+    });
+  },
+});
+
+export const { setAppError, clearAppError } = errorSlice.actions;
+
+export default errorSlice.reducer;

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -3,6 +3,7 @@ import workspaceReducer from './workspaceSlice';
 import checkpointReducer from './checkpointSlice';
 import previewReducer from './previewSlice';
 import chatReducer from './chatSlice';
+import errorReducer from './errorSlice';
 
 export const store = configureStore({
   reducer: {
@@ -10,6 +11,7 @@ export const store = configureStore({
     checkpoint: checkpointReducer,
     preview: previewReducer,
     chat: chatReducer,
+    error: errorReducer,
   },
 });
 

--- a/frontend/src/store/selectors.ts
+++ b/frontend/src/store/selectors.ts
@@ -67,3 +67,10 @@ export const selectIsSubmitDisabled = createSelector(
   [selectIsFollowUpDisabled, selectUserPrompt],
   (followUpDisabled, prompt) => followUpDisabled || !prompt.trim()
 );
+
+export const selectCurrentError = (state: RootState) => state.error.current;
+
+export const selectHasPreviewError = createSelector(
+  selectCurrentError,
+  (error) => error !== null
+);

--- a/frontend/src/store/workspaceSlice.ts
+++ b/frontend/src/store/workspaceSlice.ts
@@ -5,6 +5,7 @@ import {
   applyStepsToFiles,
   updateFileByPath,
   flattenFiles,
+  getFileByPath,
 } from '../utility/file-tree';
 import { buildModificationsBlock } from '../utility/bolt-modifications';
 import { getChatResponse, getTemplate } from '../utility/api';
@@ -178,12 +179,17 @@ const workspaceSlice = createSlice({
         const newSteps = parseXml(action.payload.chatXml);
         const { files } = applyStepsToFiles(state.files, newSteps);
         state.files = files;
+        if (state.selectedFile?.path) {
+          const synced = getFileByPath(state.files, state.selectedFile.path);
+          state.selectedFile = synced ?? null;
+        }
         state.llmMessages = action.payload.allMessages;
         state.phase = 'ready';
         delete state.activeOperations['workspace:init'];
       })
       .addCase(initWorkspace.rejected, (state, action) => {
         state.globalError = action.error.message ?? 'Failed to initialize workspace';
+        state.phase = 'ready';
         delete state.activeOperations['workspace:init'];
       })
       .addCase(submitFollowUp.pending, (state) => {
@@ -195,6 +201,10 @@ const workspaceSlice = createSlice({
         const newSteps = parseXml(action.payload.xml);
         const { files } = applyStepsToFiles(state.files, newSteps);
         state.files = files;
+        if (state.selectedFile?.path) {
+          const synced = getFileByPath(state.files, state.selectedFile.path);
+          state.selectedFile = synced ?? null;
+        }
         state.llmMessages = action.payload.allMessages;
         state.phase = 'ready';
         delete state.activeOperations['workspace:followUp'];

--- a/frontend/src/utility/error-parsing.ts
+++ b/frontend/src/utility/error-parsing.ts
@@ -1,0 +1,120 @@
+export function stripAnsi(text: string): string {
+  const ansiPattern = new RegExp(String.fromCharCode(27) + '\\[[0-9;]*[A-Za-z]', 'g');
+  return text.replace(ansiPattern, '');
+}
+
+export interface ParsedError {
+  summary: string;
+  detail: string;
+  filePath?: string;
+}
+
+export function parseViteError(output: string): ParsedError | null {
+  const cleaned = stripAnsi(output);
+
+  const patterns = [
+    /\[vite\]\s*Internal server error:/i,
+    /SyntaxError:/i,
+    /TypeError:/i,
+    /ReferenceError:/i,
+    /Cannot find module/i,
+    /Failed to resolve import/i,
+    /Unexpected token/i,
+    /Module not found/i,
+    /does not provide an export named/i,
+    /Error:/i,
+  ];
+
+  const hasError = patterns.some((p) => p.test(cleaned));
+  if (!hasError) return null;
+
+  const lines = cleaned.split('\n');
+
+  const codeFramePattern = /^\d+\s*\|/;
+  const arrowPattern = /^>\s*\d+\s*\|/;
+  const caretPattern = /^\^/;
+  const pipePattern = /^\|/;
+  const whitespacePattern = /^[\s^~]+$/;
+
+  const meaningfulLines: string[] = [];
+  for (const line of lines) {
+    if (
+      codeFramePattern.test(line) ||
+      arrowPattern.test(line) ||
+      caretPattern.test(line) ||
+      pipePattern.test(line) ||
+      whitespacePattern.test(line)
+    ) {
+      continue;
+    }
+    if (line.trim()) {
+      meaningfulLines.push(line.trim());
+    }
+  }
+
+  const summary = meaningfulLines[0] || 'Vite compilation error';
+
+  let filePath: string | undefined;
+  const fileMatch = cleaned.match(/File:\s*(.+)/i);
+  if (fileMatch) {
+    filePath = fileMatch[1].trim();
+  }
+
+  const detail = cleaned.slice(0, 500);
+
+  return { summary, detail, filePath };
+}
+
+export function parseNpmError(
+  exitCode: number,
+  output: string
+): ParsedError | null {
+  if (exitCode === 0) return null;
+
+  const cleaned = stripAnsi(output);
+  const lines = cleaned.split('\n');
+
+  const errorLines = lines.filter(
+    (line) => line.startsWith('npm ERR!') || line.toLowerCase().startsWith('npm error')
+  );
+
+  if (errorLines.length > 0) {
+    const summary = errorLines[0].replace(/^npm ERR!\s*/, '').replace(/^npm error\s*/i, '').trim();
+    const detail = errorLines.slice(0, 10).join('\n');
+    return { summary, detail };
+  }
+
+  const summary = `npm install failed with exit code ${exitCode}`;
+  const detail = `The npm install command exited with code ${exitCode}.`;
+  return { summary, detail };
+}
+
+export function parseRuntimeError(message: string, stack?: string): ParsedError {
+  const summary = message.split('\n')[0].slice(0, 200);
+  let detail = message;
+  if (stack) {
+    detail = message + '\n' + stack;
+  }
+  detail = detail.slice(0, 500);
+  return { summary, detail };
+}
+
+export function isViteSuccess(output: string): boolean {
+  const cleaned = stripAnsi(output);
+  const patterns = [
+    /ready in \d+ms/i,
+    /VITE/v,
+    /dev server running/i,
+    /built in \d+ms/i,
+  ];
+  return patterns.some((p) => p.test(cleaned));
+}
+
+export function makeDedupKey(source: string, summary: string): string {
+  const normalized = summary
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 120);
+  return `${source}::${normalized}`;
+}

--- a/frontend/src/utility/file-tree.ts
+++ b/frontend/src/utility/file-tree.ts
@@ -24,6 +24,31 @@ export function flattenFiles(
 }
 
 /**
+ * Normalize a file path to match tree format: leading slash, no trailing slash.
+ */
+function normalizePath(path: string): string {
+  const raw = path.trim().replace(/\/+$/, '') || '/';
+  return raw.startsWith('/') ? raw : `/${raw}`;
+}
+
+/**
+ * Get a single file by path from the file tree.
+ * Returns { name, content, path } for the editor/selectedFile shape, or null if not found.
+ * Path normalization is applied so paths with or without leading slash match.
+ */
+export function getFileByPath(
+  fileItems: FileItem[],
+  path: string
+): { name: string; content: string; path: string } | null {
+  const normalized = normalizePath(path);
+  const flat = flattenFiles(fileItems);
+  const entry = flat.find((e) => normalizePath(e.path) === normalized);
+  if (!entry) return null;
+  const name = entry.path.split('/').filter(Boolean).pop() ?? entry.path;
+  return { name, content: entry.content, path: entry.path };
+}
+
+/**
  * Build a WebContainer-compatible mount structure from a FileItem tree.
  */
 export function createMountStructure(files: FileItem[]): Record<string, any> {

--- a/frontend/src/utility/webcontainer-service.ts
+++ b/frontend/src/utility/webcontainer-service.ts
@@ -31,7 +31,7 @@ export async function syncChangedFiles(
       const dirPath = '/' + parts.slice(0, -1).join('/');
       try {
         await webContainer.fs.mkdir(dirPath, { recursive: true });
-      } catch (_e) {
+      } catch {
         // Directory likely already exists
       }
     }
@@ -45,7 +45,8 @@ export async function syncChangedFiles(
  * Pipes output to console. Resolves when install completes.
  */
 export async function runInstall(
-  webContainer: WebContainer
+  webContainer: WebContainer,
+  onOutput?: (data: string) => void
 ): Promise<WebContainerProcess> {
   const process = await webContainer.spawn('npm', ['install']);
 
@@ -53,6 +54,7 @@ export async function runInstall(
     new WritableStream({
       write(data) {
         console.log('[Install]', data);
+        onOutput?.(data);
       },
     })
   );
@@ -65,7 +67,8 @@ export async function runInstall(
  * Pipes output to console. Does NOT wait for exit (dev server runs indefinitely).
  */
 export async function runDevServer(
-  webContainer: WebContainer
+  webContainer: WebContainer,
+  onOutput?: (data: string) => void
 ): Promise<WebContainerProcess> {
   const process = await webContainer.spawn('npm', ['run', 'dev']);
 
@@ -73,6 +76,7 @@ export async function runDevServer(
     new WritableStream({
       write(data) {
         console.log('[Dev]', data);
+        onOutput?.(data);
       },
     })
   );
@@ -108,7 +112,7 @@ export async function waitForMount(
     try {
       await webContainer.fs.readFile('/package.json', 'utf-8');
       return true;
-    } catch (_e) {
+    } catch {
       await new Promise(resolve => setTimeout(resolve, intervalMs));
     }
   }


### PR DESCRIPTION
### ErrorBox, code tab sync, preview dot, connection errors

- ErrorBox: title 'Error Detected', subtitle, inner box, always show 'Ask to fix it'; clear on user edit; clear + hide preview dot on Ask to fix
- Code tab: getFileByPath in file-tree, sync selectedFile on init/followUp fulfilled so editor updates when LLM returns
- Preview tab: red dot inline with label; Preview shows connection error state when globalError is set
- Connection errors: phase=ready on initWorkspace.rejected; ConnectionErrorBanner with Try again (re-runs init); disable chat input when globalError; Preview tab in sync with globalError